### PR TITLE
Switched explicit device name to generic value.

### DIFF
--- a/CommonUtilities/Notify.py
+++ b/CommonUtilities/Notify.py
@@ -7,7 +7,7 @@ def send_notification(message, priority=0, image_path=None):
     params = {
         'token': keyring.get_password('Pushover', 'token'),
         'user': keyring.get_password('Pushover', 'user'),
-        'device': 'mohamediphone',
+        'device': keyring.get_password('Pushover', 'device'),
         'message': message,
         'priority': priority
     }


### PR DESCRIPTION
Changed device name used in send_notifications to get a value from keyring instead of a hard coded value. 